### PR TITLE
Disable use of NetworkManager if not usable.

### DIFF
--- a/netconnectd/server.py
+++ b/netconnectd/server.py
@@ -55,7 +55,22 @@ class Server(object):
         self.ap_name = ap_name
         self.wifi_if = wifi_if
         self.wifi_name = wifi_name
+
+        # Make sure it's safe to run nmcli
+        if wifi_free:
+            try:
+                subprocess.check_call(['nmcli', 'nm', 'status'])
+            except OSError as e:
+                self.logger.warn("Couldn't run nmcli: %s", e.message)
+                self.logger.warn("Disabling NetworkManager compatibility.")
+                wifi_free = False
+            except subprocess.CalledProcessError as e:
+                self.logger.warn("Error during test run of nmcli: %s", e.message)
+                self.logger.warn("Disabling NetworkManager compatibility.")
+                wifi_free = False
+
         self.wifi_free = wifi_free
+
         self.wifi_kill = wifi_kill
 
         self.wired_if = wired_if

--- a/netconnectd/server.py
+++ b/netconnectd/server.py
@@ -61,7 +61,8 @@ class Server(object):
             try:
                 subprocess.check_call(['nmcli', 'nm', 'status'])
             except OSError as e:
-                self.logger.warn("Couldn't run nmcli: %s", e.message)
+                self.logger.warn("Couldn't run nmcli (%s): %s", e.filename,
+                                 e.message)
                 self.logger.warn("Disabling NetworkManager compatibility.")
                 wifi_free = False
             except subprocess.CalledProcessError as e:


### PR DESCRIPTION
Check for the `nmcli` program during server startup. If it is absent or unusable, disable its use regardless of config settings until next server restart and log a warning.

This fix is motivated by the copious log messages that result if the `wifi_free` setting is incorrect.